### PR TITLE
Feature/change publication location

### DIFF
--- a/src/epublius/thoth.py
+++ b/src/epublius/thoth.py
@@ -64,7 +64,7 @@ class Thoth:
                             book_doi=book_doi, chapter_doi=chapter_doi),
                         "fullTextUrl":      urllib.parse.unquote_plus(
                             metadata.get_page_url()),
-                        "locationPlatform": "OTHER",
+                        "locationPlatform": "PUBLISHER_WEBSITE",
                         "canonical":        "true"}
             self.client.create_location(location)
 


### PR DESCRIPTION
Addresses https://github.com/OpenBookPublishers/epublius/issues/30 by changing `locationPlatform` from `OTHER` to `PUBLISHER_WEBSITE` when adding Publication Location to Thoth.